### PR TITLE
upgrade lint-staged to v13.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-vue": "^9.15.1",
-    "lint-staged": "^9.5.0",
+    "lint-staged": "^13.2.3",
     "node-sass": "^6.0.1",
     "patch-package": "^7.0.0",
     "postcss": "^8.4.24",


### PR DESCRIPTION
- `lint-staged` has been upgraded to use `v13.2.3` which will automatically add formatted code using prettier to the same commit on which it was executed.